### PR TITLE
Add .PHONY declaration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: update
+
 update:
 	git fetch -a upstream
 	git rebase upstream/master


### PR DESCRIPTION
This ensures that `make update` or just `make` will always run, even if there is a file called `update` in the repository.